### PR TITLE
Add vtkmodules to modules

### DIFF
--- a/vtk.vext
+++ b/vtk.vext
@@ -1,5 +1,6 @@
 modules:
     vtk
+    vtkmodules
 
 test_import:
     vtk


### PR DESCRIPTION
VTK 8.2 replaced vtk with vtkmodules, but kept [vtk as an alias to vtkmodules.all](https://vtk.org/doc/nightly/html/md__builds_gitlab_kitware_sciviz_ci_Documentation_Doxygen_PythonWrappers.html) for backwards-compatibility.